### PR TITLE
ci(release): run Release Please workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,13 +2,16 @@ name: release
 
 on:
   workflow_dispatch:
-  release:
-    types: [released]
+  push:
+    branches: [main]
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
-  release:
-    uses: parkerbxyz/.github/.github/workflows/release.yml@main
+  release-please:
+    uses: parkerbxyz/.github/.github/workflows/release-please.yml@main
     secrets: inherit
+    with:
+      release-type: 'node'


### PR DESCRIPTION
This repo was only running the post-release tag updater after a GitHub Release already existed, so Release Please never created or updated release PRs.

This switches the release workflow to match the working `suggest-changes` setup: pushes to `main` now call the shared Release Please workflow with the Node release type, and the workflow has permission to write pull requests.